### PR TITLE
Check for libhdfs configure-time.

### DIFF
--- a/wscript
+++ b/wscript
@@ -9,6 +9,7 @@ def set_options(opt):
 def configure(conf):
   conf.check_tool("compiler_cxx")
   conf.check_tool("node_addon")
+  conf.check_cxx(lib='hdfs', mandatory=True)
 
 def build(bld):
   obj = bld.new_task_gen("cxx", "shlib", "node_addon", includes='./src ./vendor', linkflags=['-lhdfs'])


### PR DESCRIPTION
Instead of failing on missing `libhdfs` build-time, it now complains at configure-time.
